### PR TITLE
Add deployment helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # PetworldCM
+
 Clinic Management System
+
+## Deployment scripts
+
+Two helper scripts are provided under the `scripts/` directory:
+
+- `deploy.sh` – installs dependencies, builds the React client, runs database migrations, and restarts the Node server via PM2.
+- `backup_db.sh` – creates a timestamped MySQL dump for the application database.
+
+Adjust environment variables inside each script to match your environment before execution.

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple MySQL backup script for PetworldCM
+DB_NAME="${DB_NAME:-petworld}"
+DB_USER="${DB_USER:-root}"
+BACKUP_DIR="${BACKUP_DIR:-backups}"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+mkdir -p "$BACKUP_DIR"
+
+if command -v mysqldump >/dev/null 2>&1; then
+  mysqldump -u "$DB_USER" "$DB_NAME" > "$BACKUP_DIR/${DB_NAME}_$TIMESTAMP.sql"
+  echo "Backup stored at $BACKUP_DIR/${DB_NAME}_$TIMESTAMP.sql"
+else
+  echo "mysqldump command not found; skipping backup."
+fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deployment script for PetworldCM
+# Installs dependencies, builds client, runs migrations, and restarts server.
+
+CLIENT_DIR="${CLIENT_DIR:-client}"
+SERVER_DIR="${SERVER_DIR:-server}"
+PM2_APP_NAME="${PM2_APP_NAME:-petworld-server}"
+
+echo "Starting deployment for PetworldCM"
+
+if [ ! -d "$SERVER_DIR" ] || [ ! -d "$CLIENT_DIR" ]; then
+  echo "Expected directories '$SERVER_DIR' and '$CLIENT_DIR' not found."
+  echo "Customize CLIENT_DIR and SERVER_DIR or create these folders."
+  echo "No actions were performed."
+  exit 0
+fi
+
+# Install dependencies for server and client
+npm --prefix "$SERVER_DIR" ci
+npm --prefix "$CLIENT_DIR" ci
+
+# Run database migrations if available
+if npm --prefix "$SERVER_DIR" run | grep -q '^  migrate'; then
+  npm --prefix "$SERVER_DIR" run migrate
+else
+  echo "No migrate script in server package.json; skipping migrations."
+fi
+
+# Build client and move build output to server/public
+npm --prefix "$CLIENT_DIR" run build
+rm -rf "$SERVER_DIR/public"
+cp -R "$CLIENT_DIR/build" "$SERVER_DIR/public"
+
+# Restart server using PM2 if available
+if command -v pm2 >/dev/null 2>&1; then
+  pm2 restart "$PM2_APP_NAME" || pm2 start "$SERVER_DIR" --name "$PM2_APP_NAME"
+else
+  echo "pm2 not installed; start your server manually."
+fi
+
+echo "Deployment completed."


### PR DESCRIPTION
## Summary
- add deploy script to automate build, migration, and restart
- add database backup script
- document scripts in README

## Testing
- `bash scripts/deploy.sh`
- `bash scripts/backup_db.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b7d68c630832887eca907d22ab916